### PR TITLE
Fix pattern_trit_generator for duplicate letters

### DIFF
--- a/_2022/wordle.py
+++ b/_2022/wordle.py
@@ -100,13 +100,21 @@ def get_true_wordle_prior():
 
 
 def pattern_trit_generator(guess, true_word):
-    for c1, c2 in zip(guess, true_word):
+    pattern = len(guess) * [MISS]
+    letters_left = []
+
+    for index, (c1, c2) in enumerate(zip(guess, true_word)):
         if c1 == c2:
-            yield EXACT
-        elif c1 in true_word:
-            yield MISPLACED
+            pattern[index] = EXACT
         else:
-            yield MISS
+            letters_left.append(c2)
+
+    for (index, c) in enumerate(guess):
+        if not pattern[index] and c in letters_left:
+            pattern[index] = MISPLACED
+            letters_left.remove(c)
+
+    return pattern
 
 
 def get_pattern(guess, true_word):


### PR DESCRIPTION
I'm not too familiar with Python but this is a fix for https://github.com/3b1b/videos/issues/15

The Wordle website uses a different algorithm that first checks for correct letters and will ignore duplicates.

A basic example is the word "ABCDE" and the guess "AAAAA"
- Wordle's algorithm gives the result 🟩⬛⬛⬛⬛
- This repo's algorithm gives the result 🟩🟨🟨🟨🟨

An example for the current day's instance is with the guess "ERROR":
- Wordle's algorithm gives the result 🟩⬛⬛⬛🟩
- This repo's algorithm gives the result 🟩🟨🟨⬛🟩
