### PR TITLE
Handling duplicates in guesses and actual word

### DIFF
--- a/_2022/wordle.py
+++ b/_2022/wordle.py
@@ -100,8 +100,9 @@ def get_true_wordle_prior():
 
 
 def pattern_trit_generator(guess, true_word):
-    for c1, c2 in zip(guess, true_word):
+    for i ,(c1, c2) in enumerate(zip(guess, true_word)):
         if c1 == c2:
+            true_word = "".join(list(true_word[:i]) + ["0"] + list(true_word[i+1:]))
             yield EXACT
         elif c1 in true_word:
             yield MISPLACED

--- a/_2022/wordle.py
+++ b/_2022/wordle.py
@@ -105,6 +105,8 @@ def pattern_trit_generator(guess, true_word):
             true_word = "".join(list(true_word[:i]) + ["0"] + list(true_word[i+1:]))
             yield EXACT
         elif c1 in true_word:
+            ind = true_word.index(c1)
+            true_word = "".join(list(true_word[:ind]) + ["0"] + list(true_word[ind+1:])) 
             yield MISPLACED
         else:
             yield MISS


### PR DESCRIPTION
When there's a duplicate in our guess but there's no or less duplicates in the original word, it should be handled effectively. 

**Scenario 1: When the first instance is at the correct position**
Word: ABCDE
Guess: ABACB

Current implementation shows: 
![image](https://user-images.githubusercontent.com/39518561/152828182-0e0da266-d4ad-4ae4-90e0-626857d3d64c.png)

Whereas, it should ideally be 
![image](https://user-images.githubusercontent.com/39518561/152828188-e2036d55-2819-4146-9976-b4f8b4fcd242.png)

**Scenario 2: When the first instance is at the wrong position**
Word: ABCDE
Guess: BADAE

Current implementation shows:
![image](https://user-images.githubusercontent.com/39518561/152828928-b92f9be6-77fb-4bbb-97a8-ff0e8f905013.png)

Whereas, it should ideally be
![image](https://user-images.githubusercontent.com/39518561/152829138-731767b0-3683-42a7-91a9-3ba62b1f1e88.png)


**Special Cases: When the duplicate count is less in the actual word than guess**
Word: ABBCD
Guess: ABCBB

Current implementation shows:
![image](https://user-images.githubusercontent.com/39518561/152829664-fc2ac273-7573-4740-a749-b5c778d037a6.png)

Whereas, it should ideally be 
![image](https://user-images.githubusercontent.com/39518561/152829736-d1ddffc3-9203-4f43-b9f3-d88a1b847e25.png)
