### PR TITLE
fix bug in cross product result matrix

### DIFF
--- a/_2016/eola/chapter8p2.py
+++ b/_2016/eola/chapter8p2.py
@@ -67,7 +67,7 @@ class BruteForceVerification(Scene):
         cross = Matrix(list(it.starmap(get_term, [
             (v2, w3, v3, w2),
             (v3, w1, v1, w3),
-            (v2, w3, v3, w2),
+            (v1, w2, v2, w1),
         ])))
         cross_product = VGroup(
             v.copy(), OldTex("\\times"), w.copy(),


### PR DESCRIPTION
This is to fix a typo in the matrix in the "Numerical formula" column in "Brute Force Verification" scene in `chapter8p2.py`.

Thanks for your awesome work!